### PR TITLE
Running and Building HAWQ Requires sudo in the Containers

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,7 @@ git clone https://github.com/apache/incubator-hawq.git /data/hawq
 * build Apache HAWQ
 ```
 cd /data/hawq
+sudo cpan JSON  # Choose the sudo install method and accept the defaults for everything else.
 ./configure --prefix=/data/hawq-devel
 make
 make install

--- a/README.md
+++ b/README.md
@@ -173,8 +173,8 @@ echo 'centos7-datanode3' >>  /data/hawq-devel/etc/slaves
 * Initialize Apache HAWQ cluster and create default database
 ```
 sudo chmod +x /data/hawq-devel/greenplum_path.sh
-sudo chmod 777 ls
-/data/hawq-devel/etc
+# This next command is not safe, but it's okay for a toy environment, for now.
+sudo chmod 777 /data/hawq-devel/etc
 sudo /data/hawq-devel/greenplum_path.sh && hawq init cluster
 createdb
 ```

--- a/README.md
+++ b/README.md
@@ -160,8 +160,8 @@ git clone https://github.com/apache/incubator-hawq.git /data/hawq
 cd /data/hawq
 sudo cpan JSON  # Choose the sudo install method and accept the defaults for everything else.
 ./configure --prefix=/data/hawq-devel
-make
-make install
+sudo make
+sudo make install
 ```
 * modify Apache HAWQ configuration
 ```
@@ -172,8 +172,10 @@ echo 'centos7-datanode3' >>  /data/hawq-devel/etc/slaves
 ```
 * Initialize Apache HAWQ cluster and create default database
 ```
-source /data/hawq-devel/greenplum_path.sh
-hawq init cluster
+sudo chmod +x /data/hawq-devel/greenplum_path.sh
+sudo chmod 777 ls
+/data/hawq-devel/etc
+sudo /data/hawq-devel/greenplum_path.sh && hawq init cluster
 createdb
 ```
 Now you can connect to default database with `psql` command.
@@ -187,7 +189,7 @@ gpadmin=#
 * Running tests
 ```
 cd /data/hawq
-make installcheck-good
+sudo ../hawq-devel/greenplum_path.sh && make installcheck-good
 ```
 # More command with this script
 ```


### PR DESCRIPTION
This is just to get the discussion going, mostly.  The README.md should probably document a process that actually works, rather than an ideal end-state for the process of building and running HAWQ.

Through running the build process, I also discovered that there's two failing pgTap tests: errortbl & hcatalog_lookup

I only tested on the CentOS 7 containers.

I will log Issues for getting these things fixed.
